### PR TITLE
Fix accounting bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,9 +46,12 @@ module.exports = Harvest = function (opts) {
                 'Accept': 'application/json'
             };
 
-            if (data !== 'undefined') {
-                if (data === 'object') {
-                    opts.headers['Content-Length'] = querystring.stringify(data).length;
+            if (typeof data !== 'undefined') {
+                if (typeof data === 'object') {
+                    // restler uses url encoding to transmit data
+                    // url encoding does not support data types
+                    data = JSON.stringify(data);
+                    opts.headers['Content-Length'] = data.length;
                 } else {
                     opts.headers['Content-Length'] = data.length;
                 }


### PR DESCRIPTION
Restler uses url encoding to transmit json (if it is an object)
https://github.com/danwrong/restler/blob/e70709c7f0c998118da5a7cec82fb1a90d36d411/lib/restler.js#L58-L62

Transmitting a float url encoded would mean, the server interprets the transmitted value as a string.
eg. 250.51 -> "250.51"

Harvest interprets "250.51" as 25051 (removing the dot).
When transforming the js-object to a json string, restler sends the json directly without url encoding the data.
https://github.com/danwrong/restler/blob/e70709c7f0c998118da5a7cec82fb1a90d36d411/lib/restler.js#L63-L67

Current behavior results in huge errors when creating payments.