### PR TITLE
Add options to Invoices.list

### DIFF
--- a/lib/invoices.js
+++ b/lib/invoices.js
@@ -6,6 +6,7 @@ module.exports = Invoices = function (api) {
 };
 
 Invoices.prototype.list = function (options, cb) {
+    options = options ? options : {};
     var url = '/invoices';
     this.client.get(url, {}, cb);
 };


### PR DESCRIPTION
GET /invoices has filter and pagination options, but they are currently not usable.
The limit if invoices returned by the api is 50, therefore to work with invoices these options are required.
https://github.com/harvesthq/api/blob/master/Sections/Invoices.md

Changes are compatible with my previous PR:
https://github.com/log0ymxm/node-harvest/pull/32
