### PR TITLE
npm run test / Run tests with --no-timeouts by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Harvest API client library",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --no-timeouts"
   },
   "repository": "https://github.com/log0ymxm/node-harvest",
   "author": "Paul English",


### PR DESCRIPTION
Hey! Harvest reacts longer than 2 seconds sometimes, what causes fails. I suppose running tests without timeouts would be a better choice for defaults. Keen to hear any other suggestions!