### PR TITLE
Implement oAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,34 +10,86 @@ Harvest is a tool that enables businesses to track time, track projects, manage 
 
 # Usage
 
-    var Harvest = require('harvest'),
-    	harvest = new Harvest({
-            subdomain: config.harvest.subdomain,
-            email: config.harvest.email,
-            password: config.harvest.password
-        }),
-        TimeTracking = harvest.TimeTracking;
+## Basic Authentication
+
+```js
+var Harvest = require('harvest'),
+    harvest = new Harvest({
+        subdomain: config.harvest.subdomain,
+        email: config.harvest.email,
+        password: config.harvest.password
+    }),
+    TimeTracking = harvest.TimeTracking;
+
+TimeTracking.daily({}, function(err, tasks) {
+    if (err) throw new Error(err);
+
+// work with tasks
+});
+```
+## OAuth Authentication
+
+### When you already have an access token
+
+```js
+var harvest_with_token = new Harvest({
+    subdomain: config.harvest_oauth.subdomain,
+    access_token: stored_access_token
+});
+
+var TimeTracking = harvest.TimeTracking;
+
+TimeTracking.daily({}, function(err, tasks) {
+    if (err) throw new Error(err);
+
+    console.log('Loaded tasks using passed in auth_token!');
+});
+```
+
+### To get an access token which can then be stored and used in future
+
+```js
+// See https://platform.harvestapp.com/oauth2_clients to get these
+var harvest = new Harvest({
+    subdomain: config.harvest_oauth.subdomain,
+    redirect_uri: config.harvest_oauth.redirect_uri,
+    identifier: config.harvest_oauth.client_id,
+    secret: config.harvest_oauth.secret
+});
+
+// Send the user to harvest.getAccessTokenURL()) and grab the access code passed as a get parameter
+// e.g. By running an express.js server at redirect_url
+var access_code = req.query.code;
+
+harvest.parseAccessCode(access_code, function(access_token) {
+    console.log('Grabbed the access token to save', access_token);
+
+    var TimeTracking = harvest.TimeTracking;
 
     TimeTracking.daily({}, function(err, tasks) {
         if (err) throw new Error(err);
 
-	// work with tasks
+        console.log('Loaded tasks using oauth!');
     });
+});
+```
 
 # Testing
 
 In order to test you will need to create a config file that uses your credentials inside `config/default.json`
 
-    {
-      "harvest": {
-        "subdomain": "...",
-        "email": "...",
-        "password": "...",
-        "identifier": "...",
-        "secret": "...",
-        "user_agent": "node-harvest test runner"
-      }
-    }
+```js
+{
+  "harvest": {
+    "subdomain": "...",
+    "email": "...",
+    "password": "...",
+    "identifier": "...",
+    "secret": "...",
+    "user_agent": "node-harvest test runner"
+  }
+}
+```
 
 This API is designed to work either using HTTP Basic authentication, or OAuth so either set of credentials will work. Subdomain is always required.
 


### PR DESCRIPTION
There are two ways to use oauth, by passing in a valid access token when instantiating Node-Harvest or using the oAuth flow, calling `this.parseAccessCode()` with an access code provided by Harvest after
hitting the URL in `this.getAccessTokenURL()`

Typically you'd pass a `redirect_uri` that was handled by your node process (such as a server running with Express.js) and grab the code from the get parameters but in this example I'm simply asking the user to copy and paste the secret from the URL.

I have a follow up PR ready to support oAuth in the file upload PR I opened earlier today (#45) in the branch [add-oauth-support-to-image-upload](https://github.com/Pezmc/node-harvest/compare/add-oauth-support...Pezmc:add-oauth-support-to-image-upload).

Example usage (see https://github.com/Pezmc/test-node-harvest/blob/master/test-oauth.js):

``` js
var harvest_with_token = new Harvest({
    subdomain: config.harvest_oauth.subdomain,
    access_token: access_token
});

var TimeTracking = harvest.TimeTracking;

TimeTracking.daily({}, function(err, tasks) {
    if (err) throw new Error(err);

    console.log('Loaded tasks using passed in auth_token!');
});
```

or

``` js
var harvest = new Harvest({
    subdomain: config.harvest_oauth.subdomain,
    identifier: config.harvest_oauth.client_id,
    secret: config.harvest_oauth.secret,
    redirect_uri: config.harvest_oauth.redirect_uri
});

console.log('Visit the following and paste the access code param from the url here', harvest.getAccessTokenURL());

rl.question("Code from the URL: ", function(answer) {
    rl.close();

    harvest.parseAccessCode(answer.trim(), function(access_token) {
        console.log('Grabbed the access token', access_token);

        var TimeTracking = harvest.TimeTracking;

        TimeTracking.daily({}, function(err, tasks) {
            if (err) throw new Error(err);

            console.log('Loaded tasks using oauth!');
        });
    })
});
```
