### PR TITLE
Added slim functionality to time-tracking

### DIFF
--- a/lib/time-tracking.js
+++ b/lib/time-tracking.js
@@ -20,6 +20,12 @@ TimeTracking.prototype.daily = function (options, cb) {
         delete options.of_user;
     }
 
+    if(!_isUndefined(options, 'slim')) {
+        url += '?slim=' + options.slim;
+
+        delete options.slim;
+    }
+
     this.client.get(url, {}, cb);
 };
 


### PR DESCRIPTION
Includes the functionality to return only tracked time, and no assignments.

As per the Harvest API documentation
GET https://YOURACCOUNT.harvestapp.com/daily?slim=1

Retrieves entries for today paired with the projects and tasks that can be added to the timesheet by the requesting user.

I also wanted to updated the test for this parameter but I wasn't sure if I should, seeing that the tests are specific to a given harvest account.  Please let me know if I should update the test as wel..