### PR TITLE
support fetching multiple pages of invoices

### DIFF
--- a/lib/invoices.js
+++ b/lib/invoices.js
@@ -6,8 +6,27 @@ module.exports = Invoices = function (api) {
 };
 
 Invoices.prototype.list = function (options, cb) {
-    var url = '/invoices';
-    this.client.get(url, {}, cb);
+    var self = this;
+
+    var invoices = [];
+
+    function fetch_invoices(data, callback, page){
+        var url = '/invoices';
+        if(page !== undefined){ url += "?page=" + page; }
+
+        self.client.get(url, {}, function(err, new_invoices){
+            if(err){ return callback(err); }
+            data.push.apply(data, new_invoices);
+
+            if(!options.all || new_invoices.length < 50){
+                return callback(null, data);
+            }else{
+                return fetch_invoices(data, callback, page+1);
+            }
+        });
+    }
+
+    return fetch_invoices(invoices, cb, options.all ? 1 : options.page);
 };
 
 Invoices.prototype.get = function (options, cb) {


### PR DESCRIPTION
The API limits you to 50 invoices per page. Now you can specify a page, and also have an option to fetch all your invoices.

Nice library. Thanks!
