### PR TITLE
pass querystring to rest service

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ module.exports = Harvest = function (opts) {
                 'Accept': 'application/json'
             };
 
+            if (data.query) {
+                opts.query = data.query;
+                delete data.query;
+            }
+
             if (typeof data !== 'undefined') {
                 if (typeof data === 'object') {
                     // restler uses url encoding to transmit data


### PR DESCRIPTION
My two cents on this. Cause #34 seems abandoned.

Now I can do 

```
harvest.Invoices.list({query: 'status[]=pastdue&status[]=draft'}, (err,data) => {});
```
