### PR TITLE
Added filter options to timeEntriesByProject

### DIFF
--- a/lib/reports.js
+++ b/lib/reports.js
@@ -11,8 +11,32 @@ Reports.prototype.timeEntriesByProject = function (options, cb) {
                             for the project. It also requires UTC dates (e.g. YYYYMMDD) \
                             for both the from date and the to date'));
     }
+    var filters = '';
 
-    var url = '/projects/' + options.project_id + '/entries?from=' + options.from + '&to=' + options.to;
+    if (options.billable === true || options.billable === 'yes') {
+      filters += '&billable=yes';
+    }
+
+    if (options.only_billed === true || options.only_billed === 'yes') {
+      filters += '&only_billed=yes';
+    }
+
+    if (options.only_unbilled === true || options.only_unbilled === 'yes') {
+      filters += '&only_unbilled=yes';
+    }
+
+    if (options.is_closed === true || options.is_closed === 'yes') {
+      filters += '&is_closed=yes';
+    }
+
+    if (options.updated_since) {
+      filters += '&updated_since=' + options.updated_since;
+    }
+
+    if (options.user_id) {
+      filters += '&user_id=' + options.user_id;
+    }
+    var url = '/projects/' + options.project_id + '/entries?from=' + options.from + '&to=' + options.to + filters;
     this.client.get(url, {}, cb);
 };
 


### PR DESCRIPTION
I added the filter variable to the timeEntriesByProject.  It checks for the following in options parameters:
1. billable.
2. only_billed
3. only_unbilled
4. is_closed
5. updated_since
6. user_id

These are acceptable option parameters per the Harvest API documentation. http://help.getharvest.com/api/reports-api/reports/time-reports/

This was already done for timeEntriesByUser function below this one. I hope it is useful.
