### PR TITLE
	Expense: impersonating another user with "of_user"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: true
+sudo: false
 node_js:
   - '0.12'
   - '0.11'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-sudo: false
+sudo: true
 node_js:
   - '0.12'
   - '0.11'

--- a/lib/expenses.js
+++ b/lib/expenses.js
@@ -1,4 +1,14 @@
+var appendQuery = require('append-query');
+
 var Expenses, _isUndefined = require('../mixin');
+
+function ofUserUrl(url, options) {
+    if (options.of_user) {
+        url = appendQuery(url, {of_user: options.of_user});
+        delete options.of_user;
+        return url;
+    }
+}
 
 module.exports = Expenses = function (api) {
     this.api = api;
@@ -7,6 +17,8 @@ module.exports = Expenses = function (api) {
 
 Expenses.prototype.list = function (options, cb) {
     var url = '/expenses';
+    url = ofUserUrl(url, options);
+
     this.client.get(url, {}, cb);
 };
 
@@ -16,11 +28,15 @@ Expenses.prototype.get = function (options, cb) {
     }
 
     var url = '/expenses/' + options.id;
+    url = ofUserUrl(url, options);
+
     this.client.get(url, {}, cb);
 };
 
 Expenses.prototype.create = function (options, cb) {
     var url = '/expenses';
+    url = ofUserUrl(url, options);
+
     delete options.id;
     this.client.post(url, options, cb);
 };
@@ -31,6 +47,8 @@ Expenses.prototype.update = function (options, cb) {
     }
 
     var url = '/expenses/' + options.id;
+    url = ofUserUrl(url, options);
+
     delete options.id;
     this.client.put(url, options, cb);
 };
@@ -41,6 +59,8 @@ Expenses.prototype.delete = function (options, cb) {
     }
 
     var url = '/expenses/' + options.id;
+    url = ofUserUrl(url, options);
+
     this.client.delete(url, {}, cb);
 };
 
@@ -66,6 +86,8 @@ Expenses.prototype.attachReceipt = function (options, cb) {
     // ------------------------------b7edea381b46
 
     var url = '/expenses/' + options.id + '/receipt';
+    url = ofUserUrl(url, options);
+
     this.client.post(url, {}, cb);
 };
 
@@ -75,5 +97,7 @@ Expenses.prototype.getReceipt = function (options, cb) {
     }
 
     var url = '/expenses/' + options.id + '/receipt';
+    url = ofUserUrl(url, options);
+
     this.client.get(url, {}, cb);
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "Paul English",
   "license": "MIT",
   "dependencies": {
+    "append-query": "^1.1.0",
     "async": "^1.5.0",
     "day-of-year": "^0.1.0",
     "request": "~2.55.0",


### PR DESCRIPTION
Recently, Harvest team changed the behaviour of the Expense API. When attaching an expense to a project through the API, the user who is submitting the expense must belong to the project.

The `of_user` option (in the query string) helps an administrator to submit an expense for another user.

All Expense methods have been modified here to accept this option, `of_user`:

````
Expense.create({
    of_user: '1234',
    expense: {
         project_id: '4567',
         total_cost: 99
   }
}
````

See `of_user` description in Harvest API documentation: http://help.getharvest.com/api/expenses-api/expenses/add-update-expenses/