### PR TITLE
Pass options in TimeTracking.prototype.daily

### DIFF
--- a/lib/api/time-tracking.js
+++ b/lib/api/time-tracking.js
@@ -25,7 +25,7 @@ TimeTracking.prototype.daily = function(options, cb) {
     delete options.date;
   }
 
-  this.harvest.request('GET', uri, {}, cb);
+  this.harvest.request('GET', uri, options, cb);
 };
 
 /**


### PR DESCRIPTION
I figured out why the `of_user` option wasn't being passed to the request as a query string, this function wasn't passing an empty object instead of the options argument.