### PR TITLE
Wrong reference to redirect_uri in getAccessTokenURL

### DIFF
--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -93,7 +93,7 @@ Harvest.prototype.request = function request(method, uri, data, cb) {
 Harvest.prototype.getAccessTokenURL = function() {
   return this.host +
     '/oauth2/authorize?client_id=' + this.identifier +
-    '&redirect_uri=' + encodeURIComponent(this.redirect_uri) +
+    '&redirect_uri=' + encodeURIComponent(this.redirectUri) +
     '&response_type=code';
 };
 


### PR DESCRIPTION
On line 96 the parameter should be `gthis.redirectUri`